### PR TITLE
Trying to generalise functionality to make a static file server

### DIFF
--- a/lib/raxx/static.ex
+++ b/lib/raxx/static.ex
@@ -11,6 +11,7 @@ defmodule Raxx.Static do
     plug doesnt actually gzip it just assumes a file named path <>.gz
     gzip is assumed false by default, say true to generate gz from contents or path modification if zipped exists.
     https://groups.google.com/forum/#!topic/elixir-lang-talk/RL-qWWx9ILE
+    zipping could be a middleware thing
   - have an overwritable not_found function
   - cache control time
   - Etags
@@ -27,7 +28,14 @@ defmodule Raxx.Static do
     end
   end
 
-  @doc false
+  @doc """
+  serve a single file,
+  
+  options need to include
+  - overriding mime time
+  - overridding headers in general
+  - if path absolute use last part?
+  """
   def serve_file_ast(filename, path) do
     request_match = quote do: %{path: unquote(path)}
     mime = MIME.from_path(filename)
@@ -54,8 +62,21 @@ defmodule Raxx.Static do
   end
 
   @doc """
-  Serve a director of assets
+  Serve a directory of static content
   TODO: pass a glob patter or array of patterns.
+  
+  options (handle as map and keyword)
+  - *files*: relative to dir, eg ["./README.md", "./**/*.css"]
+    work without needed begining ./
+  - *logger*: maybe or as middleware instead
+  - *max_size*: stop loading to memory files that are too big.
+    eventually build a system where you don't need to choose
+    just loads up all it can at boot time and leaves the rest in files/compiled source
+  - *path_prefix*: I can imagine people want this (add a prefix for path)
+    I would never use this and just mount the whole controller. code over configuration
+  
+  don't define a 404 if you want this to be used with other routes.
+  not a problem if you always have a namespaced assets controller.
   """
   defmacro serve_dir(dir) do
     quote do

--- a/lib/raxx/static.ex
+++ b/lib/raxx/static.ex
@@ -53,6 +53,10 @@ defmodule Raxx.Static do
     end
   end
 
+  @doc """
+  Serve a director of assets
+  TODO: pass a glob patter or array of patterns.
+  """
   defmacro serve_dir(dir) do
     quote do
       dir = Path.expand(unquote(dir), Path.dirname(__ENV__.file))


### PR DESCRIPTION
Implement a Raxx endpoint that serves a folder of static content.

The server reads all the content at compile time. It should assume a bunch of default.

```elixir
defmodule Assets do
  use Raxx.Static
  # This assumes the files are in the directory `./static` and includes all of them.
  # options will include pointing to a different directory or what files to exclude
end
```
The current tests fail once a second file is included. in this case site.css it seams that the pattern match is not  being unquoted as I expected. I am doubly confused because the match is not catching all requests because the 404 test is passing.

*Cloning the static branch at this point has one failing test* this is what needs fixing before merging.