### PR TITLE
Added ssl init function

### DIFF
--- a/raxx_cowboy/lib/raxx/cowboy/handler.ex
+++ b/raxx_cowboy/lib/raxx/cowboy/handler.ex
@@ -48,9 +48,6 @@ defmodule Raxx.Cowboy.Handler do
   end
 
   defp normalise_request(req) do
-    IO.puts "req:
-#{inspect(req, [pretty: true, limit: :infinity, width: :infinity])}"
-
     # Server information
     {host, req} = :cowboy_req.host req
 

--- a/raxx_elli/lib/raxx/elli/handler.ex
+++ b/raxx_elli/lib/raxx/elli/handler.ex
@@ -34,7 +34,7 @@ defmodule Raxx.Elli.Handler do
     # [host, port] = String.split(authority, ":") - authority might not contain a port, and may crash here
     [host, port] = case String.split(authority, ":") do
        [host, port] -> [host, port]
-       [host] -> [host, 80] # we need to set the correct port some how...
+       [host] -> [host, "80"] # we need to set the correct port some how...
      end
      
     %{

--- a/raxx_elli/lib/raxx/elli/handler.ex
+++ b/raxx_elli/lib/raxx/elli/handler.ex
@@ -31,16 +31,15 @@ defmodule Raxx.Elli.Handler do
       {String.downcase(k), String.downcase(v)}
     end)
 
-	[host, port] = 
-	case :elli_request.headers(elli_request) |> List.keyfind("Host", 0) do
-	  {"Host", authority} ->
-		case String.split(authority, ":") do
-			[host, port] -> [host, port]
-			[host] -> [host, "80"] # we need to set the correct port some how...
-		end
-	  _ -> ["", "0"]	
-	end
-     
+  [host, port] = case :elli_request.headers(elli_request) |> List.keyfind("Host", 0) do
+    {"Host", authority} ->
+      case String.split(authority, ":") do
+        [host, port] -> [host, port]
+        [host] -> [host, "80"] # we need to set the correct port some how...
+      end
+    _ -> ["", "80"]
+  end
+
     %{
       scheme: "http", # we need to set the correct scheme too for :ssl
       host: host,

--- a/raxx_elli/lib/raxx/elli/handler.ex
+++ b/raxx_elli/lib/raxx/elli/handler.ex
@@ -30,12 +30,16 @@ defmodule Raxx.Elli.Handler do
     headers = :elli_request.headers(elli_request) |> Enum.map(fn ({k, v}) ->
       {String.downcase(k), String.downcase(v)}
     end)
-    {"Host", authority} = :elli_request.headers(elli_request) |> List.keyfind("Host", 0)
-    # [host, port] = String.split(authority, ":") - authority might not contain a port, and may crash here
-    [host, port] = case String.split(authority, ":") do
-       [host, port] -> [host, port]
-       [host] -> [host, "80"] # we need to set the correct port some how...
-     end
+
+	[host, port] = 
+	case :elli_request.headers(elli_request) |> List.keyfind("Host", 0) do
+	  {"Host", authority} ->
+		case String.split(authority, ":") do
+			[host, port] -> [host, port]
+			[host] -> [host, "80"] # we need to set the correct port some how...
+		end
+	  _ -> ["", "0"]	
+	end
      
     %{
       scheme: "http", # we need to set the correct scheme too for :ssl

--- a/raxx_elli/lib/raxx/elli/handler.ex
+++ b/raxx_elli/lib/raxx/elli/handler.ex
@@ -31,9 +31,14 @@ defmodule Raxx.Elli.Handler do
       {String.downcase(k), String.downcase(v)}
     end)
     {"Host", authority} = :elli_request.headers(elli_request) |> List.keyfind("Host", 0)
-    [host, port] = String.split(authority, ":")
+    # [host, port] = String.split(authority, ":") - authority might not contain a port, and may crash here
+    [host, port] = case String.split(authority, ":") do
+       [host, port] -> [host, port]
+       [host] -> [host, 80] # we need to set the correct port some how...
+     end
+     
     %{
-      scheme: "http",
+      scheme: "http", # we need to set the correct scheme too for :ssl
       host: host,
       port: :erlang.binary_to_integer(port),
       method: method,


### PR DESCRIPTION
The raxx_cowboy example would need this modification as well to run ssl

  def start(_type, _args) do
    routes = [
      {:_, Raxx.Cowboy.Handler, {__MODULE__, []}}
    ]

    dispatch = :cowboy_router.compile([{:_, routes}])

    opts = [ port: 88,
          keyfile: "C:/Elixir/webraxx/config/paperless_bots.key",
         certfile: "C:/Elixir/webraxx/config/paperless_bots.pem",
           dhfile: "C:/Elixir/webraxx/config/dhparams.pem"]

    env = [dispatch: dispatch]

    # Don't forget can set any name
    {:ok, _pid} = :cowboy.start_https(:https, 100, opts, [env: env])
  end