### PR TITLE
Case-Insensitive and duplicate headers are valid.

### DIFF
--- a/lib/raxx.ex
+++ b/lib/raxx.ex
@@ -255,14 +255,6 @@ defmodule Raxx do
       [{"referer", "example.com"}, {"accept", "text/html"}]
   """
   def set_header(message = %{headers: headers}, name, value) do
-    if String.downcase(name) != name do
-      raise "Header keys must be lowercase"
-    end
-
-    if :proplists.is_defined(name, headers) do
-      raise "Headers should not be duplicated"
-    end
-
     %{message | headers: headers ++ [{name, value}]}
   end
 


### PR DESCRIPTION
I think the responsibility of having duplicate headers should be left to the user.
https://tools.ietf.org/html/rfc7230#section-3.2.2 suggests that in some cases it is allowed.

Also, as per rfc, case-insensitive headers are valid