### PR TITLE
Fix line spliting when generating named response statuses

### DIFF
--- a/lib/raxx.ex
+++ b/lib/raxx.ex
@@ -129,7 +129,7 @@ defmodule Raxx do
   filepath = Path.join(__DIR__, "status.rfc7231")
   @external_resource filepath
   {:ok, file} = File.read(filepath)
-  status_lines = String.split(String.trim(file), "\n")
+  status_lines = String.split(String.trim(file), ~r/\R/)
   statuses = status_lines |> Enum.map(fn(status_line) ->
     {code, " " <> reason_phrase} = Integer.parse(status_line)
     {code, reason_phrase}


### PR DESCRIPTION
Ensure splitting `status.rfc7231` is not sensitive to different OS `line-endings`