### PR TITLE
add not in spec status, extras should be configurable

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,0 +1,3 @@
+use Mix.Config
+
+config :raxx, :extra_statuses, [{422, "Unprocessable Entity"}]

--- a/lib/raxx.ex
+++ b/lib/raxx.ex
@@ -165,6 +165,8 @@ defmodule Raxx do
          {code, reason_phrase}
        end)
 
+  statuses = statuses ++ Application.get_env(:raxx, :extra_statuses, [])
+
   for {status_code, reason_phrase} <- statuses do
     reason =
       reason_phrase
@@ -178,7 +180,13 @@ defmodule Raxx do
   end
 
   @doc """
-  The RFC7231 specified reason phrase for each known HTTP status code
+  The RFC7231 specified reason phrase for each known HTTP status code.
+  Extra reason phrases can be defined in raxx config under extra_status.
+
+  Default configuration is
+
+      config :raxx,
+        :extra_statuses, ["422", "Unprocessable Entity"]
 
   ## Examples
 
@@ -187,6 +195,9 @@ defmodule Raxx do
 
       iex> reason_phrase(500)
       "Internal Server Error"
+
+      iex> reason_phrase(422)
+      "Unprocessable Entity"
   """
   @spec reason_phrase(integer) :: String.t()
   for {status_code, reason_phrase} <- statuses do

--- a/lib/status.rfc7231
+++ b/lib/status.rfc7231
@@ -39,4 +39,3 @@
 503 Service Unavailable
 504 Gateway Timeout
 505 HTTP Version Not Supported
-422 Unprocessable Entity

--- a/lib/status.rfc7231
+++ b/lib/status.rfc7231
@@ -39,3 +39,4 @@
 503 Service Unavailable
 504 Gateway Timeout
 505 HTTP Version Not Supported
+422 Unprocessable Entity


### PR DESCRIPTION
This PR should be replaced with a way to add extra status to raxx. or require replying with `{422, "Some Thing"}` or is it acceptable to return blank as http2 does not have reason phrases