### PR TITLE
Basic logger middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Added
+
+- `Raxx.Logger` middleware for basic request logging.
+
 ## [0.14.6](https://github.com/CrowdHailer/raxx/tree/0.14.6) - 2018-01-03
 
 ## Fixed

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@
 
 ## Extensions
 
+This project includes `Raxx.Router` & `Raxx.Logger`.
+Listed are additional utilities that can be used in Raxx applications.
+
 - [Raxx.MethodOverride](https://github.com/CrowdHailer/raxx_method_override)
 - [Raxx.Static](https://github.com/CrowdHailer/raxx_static)
 - [Raxx.ApiBlueprint](https://github.com/CrowdHailer/raxx_api_blueprint)
@@ -176,9 +179,9 @@ end
   `handle_data` will be invoked as each part arrives.
   An application should never assume how a body will be broken into data parts.*
 
-#### Routing
+#### Router
 
-the `Raxx.Router` can be used to match requests to specific server modules.
+The `Raxx.Router` can be used to match requests to specific server modules.
 
 ```elixir
 defmodule MyApp do
@@ -193,3 +196,8 @@ defmodule MyApp do
   ]
 end
 ```
+
+#### Logger
+
+The `Raxx.Logger` can be used in any raxx server module to add basic logs.
+The format of the logs matches the format of the basic Plug logger.

--- a/lib/raxx.ex
+++ b/lib/raxx.ex
@@ -326,6 +326,19 @@ defmodule Raxx do
     |> String.split("/", trim: true)
   end
 
+  def normalized_path(request) do
+    query_string =
+      case URI.encode_query(request.query || %{}) do
+        "" ->
+          ""
+
+        encoded ->
+          "?" <> encoded
+      end
+
+    "/" <> Enum.join(request.path, "/") <> query_string
+  end
+
   @doc """
   Can application be run by compatable server?
 

--- a/lib/raxx/logger.ex
+++ b/lib/raxx/logger.ex
@@ -1,0 +1,95 @@
+defmodule Raxx.Logger do
+  @moduledoc """
+  Middleware for basic logging in the format:
+
+      GET /index.html
+      Sent 200 in 572ms
+
+  May be used in any `Raxx.Server` module.
+
+      use Raxx.Logger, level: :debug
+
+  ## Options
+
+    - `:level` - The log level this middleware will use for request and response information.
+      Default is `:info`.
+  """
+  require Logger
+
+  defmacro __using__(options) do
+    {options, []} = Module.eval_quoted(__CALLER__, options)
+    level = Keyword.get(options, :level, :info)
+
+    quote do
+      @raxx_logger_level unquote(level)
+      @before_compile unquote(__MODULE__)
+    end
+  end
+
+  defmacro __before_compile__(env) do
+    quote do
+      defoverridable Raxx.Server
+
+      @impl Raxx.Server
+      def handle_head(head, config) do
+
+        unquote(__MODULE__).process_head(head, @raxx_logger_level)
+        super(head, config)
+        |> unquote(__MODULE__).process_response(@raxx_logger_level)
+      end
+
+      def handle_data(data, config) do
+        super(data, config)
+        |> unquote(__MODULE__).process_response(@raxx_logger_level)
+      end
+
+      def handle_tail(tail, config) do
+        super(tail, config)
+        |> unquote(__MODULE__).process_response(@raxx_logger_level)
+      end
+
+      def handle_info(message, config) do
+        super(message, config)
+        |> unquote(__MODULE__).process_response(@raxx_logger_level)
+      end
+    end
+  end
+
+  @doc false
+  def process_head(head, level) do
+    Logger.log level, fn() ->
+      Process.put(unquote(__MODULE__), %{start: System.monotonic_time()})
+      [Atom.to_string(head.method), ?\s, Raxx.normalized_path(head)]
+    end
+  end
+
+  @doc false
+  def process_response(response = %Raxx.Response{}, level) do
+    log_response(response, level)
+    response
+  end
+  def process_response(reaction = {[response = %Raxx.Response{} | _parts], _state}, level) do
+    log_response(response, level)
+    reaction
+  end
+  def process_response(reaction, _level) do
+    reaction
+  end
+
+  defp log_response(response, level) do
+    Logger.log level, fn() ->
+      %{start: start} = Process.get(__MODULE__)
+      stop = System.monotonic_time()
+      diff = System.convert_time_unit(stop - start, :native, :micro_seconds)
+
+      [response_type(response), ?\s, Integer.to_string(response.status),
+      " in ", formatted_diff(diff)]
+    end
+  end
+
+  defp formatted_diff(diff) when diff > 1000, do: [diff |> div(1000) |> Integer.to_string, "ms"]
+  defp formatted_diff(diff), do: [Integer.to_string(diff), "µs"]
+
+  defp response_type(%{state: :set_chunked}), do: "Chunked"
+  defp response_type(_), do: "Sent"
+end

--- a/lib/raxx/logger.ex
+++ b/lib/raxx/logger.ex
@@ -26,7 +26,7 @@ defmodule Raxx.Logger do
     end
   end
 
-  defmacro __before_compile__(env) do
+  defmacro __before_compile__(_env) do
     quote do
       defoverridable Raxx.Server
 

--- a/lib/raxx/logger.ex
+++ b/lib/raxx/logger.ex
@@ -80,7 +80,7 @@ defmodule Raxx.Logger do
     Logger.log level, fn() ->
       %{start: start} = Process.get(__MODULE__)
       stop = System.monotonic_time()
-      diff = System.convert_time_unit(stop - start, :native, :micro_seconds)
+      diff = System.convert_time_unit(stop - start, :native, :microsecond)
 
       [response_type(response), ?\s, Integer.to_string(response.status),
       " in ", formatted_diff(diff)]
@@ -90,6 +90,6 @@ defmodule Raxx.Logger do
   defp formatted_diff(diff) when diff > 1000, do: [diff |> div(1000) |> Integer.to_string, "ms"]
   defp formatted_diff(diff), do: [Integer.to_string(diff), "µs"]
 
-  defp response_type(%{state: :set_chunked}), do: "Chunked"
+  defp response_type(%{body: true}), do: "Chunked"
   defp response_type(_), do: "Sent"
 end


### PR DESCRIPTION
Spike of logger middleware. Basically a port of the `Plug.Logger` https://github.com/elixir-plug/plug/blob/master/lib/plug/logger.ex

tackles issue #73 