### PR TITLE
Move path parsing to middleware

### DIFF
--- a/lib/raxx.ex
+++ b/lib/raxx.ex
@@ -70,10 +70,10 @@ defmodule Raxx do
       :HEAD
 
       iex> request(:GET, "/").path
-      []
+      "/"
 
       iex> request(:GET, "/foo/bar").path
-      ["foo", "bar"]
+      "/foo/bar"
 
       iex> request(:GET, "https:///").scheme
       :https
@@ -119,14 +119,13 @@ defmodule Raxx do
 
     # DEBT in case of path '//' then parsing returns path of nil.
     # e.g. localhost:8080//
-    segments = split_path(url.path || "/")
 
     struct(
       Raxx.Request,
       scheme: scheme,
       authority: url.authority,
       method: method,
-      path: segments,
+      path: url.path,
       query: url.query,
       headers: [],
       body: false
@@ -530,22 +529,9 @@ defmodule Raxx do
     "<html><body>This resource has moved <a href=\"#{html}\">here</a>.</body></html>"
   end
 
-  @doc """
-  Split a path on forward slashes.
-
-  ## Examples
-
-      iex> split_path("/foo/bar")
-      ["foo", "bar"]
-
-  """
-  @spec split_path(String.t()) :: [String.t()]
-  def split_path(path_string) do
-    path_string
-    |> String.split("/", trim: true)
-  end
-
   def normalized_path(request) do
+    request = Raxx.ParsePath.split_path(request)
+
     query_string =
       case request.query do
         nil ->

--- a/lib/raxx/parse_path.ex
+++ b/lib/raxx/parse_path.ex
@@ -1,0 +1,49 @@
+defmodule Raxx.ParsePath do
+  @moduledoc """
+  Tokenize path elements. Replaces the raw path (`binary`) in `%Request.path` with `[binary]`
+
+  To use this middleware just use it in any Raxx.Server module.
+
+      use Raxx.ParsePath
+  """
+
+  defmacro __using__(_options) do
+    quote do
+      @before_compile unquote(__MODULE__)
+    end
+  end
+
+  defmacro __before_compile__(__env) do
+    quote do
+      defoverridable Raxx.Server
+
+      @impl Raxx.Server
+      def handle_head(head, config) do
+        head = unquote(__MODULE__).split_path(head)
+        super(head, config)
+      end
+    end
+  end
+
+  @doc """
+  Splits path string into multiple segments.
+
+  ## Examples
+      iex> request(:GET, "/foo/bar/")
+      ...> |> split_path()
+      ...> |> Map.get(:path)
+      ["foo", "bar"]
+  """
+  def split_path(%Raxx.Request{path: path} = head) when is_binary(path) do
+    split_path = String.split(path, "/", trim: true)
+    %{head | path: split_path}
+  end
+
+  def split_path(%Raxx.Request{path: nil} = head) do
+    %{head | path: []}
+  end
+
+  def split_path(path) do
+    path
+  end
+end

--- a/lib/raxx/request.ex
+++ b/lib/raxx/request.ex
@@ -43,7 +43,7 @@ defmodule Raxx.Request do
           authority: binary,
           method: method,
           mount: [binary],
-          path: [binary],
+          path: binary | [binary],
           query: binary | nil,
           headers: Raxx.headers(),
           body: Raxx.body()

--- a/lib/raxx/server.ex
+++ b/lib/raxx/server.ex
@@ -187,6 +187,7 @@ defmodule Raxx.Server do
     quote do
       @behaviour unquote(__MODULE__)
 
+      use Raxx.ParsePath
       use Raxx.NotFound
 
       import Raxx

--- a/test/raxx/logger_test.exs
+++ b/test/raxx/logger_test.exs
@@ -32,7 +32,7 @@ defmodule Raxx.LoggerTest do
     assert :http = Keyword.get(metadata, :"raxx.scheme")
     assert "example.com:1234" = Keyword.get(metadata, :"raxx.authority")
     assert :GET = Keyword.get(metadata, :"raxx.method")
-    assert "[\"foo\"]" = Keyword.get(metadata, :"raxx.path")
+    assert "\"/foo\"" = Keyword.get(metadata, :"raxx.path")
     assert "\"bar=value\"" = Keyword.get(metadata, :"raxx.query")
   end
 end

--- a/test/raxx/parse_path_test.exs
+++ b/test/raxx/parse_path_test.exs
@@ -1,0 +1,18 @@
+defmodule Raxx.ParsePathTest do
+  use ExUnit.Case
+  import Raxx
+  import Raxx.ParsePath
+
+  doctest Raxx.ParsePath
+
+  test "parse a path" do
+    request = request(:GET, "/foo/bar/baz/")
+    assert ["foo", "bar", "baz"] == split_path(request).path
+  end
+
+  test "doesn't process request where path isn't a string" do
+    request = request(:GET, "/foo/bar/")
+    request = %{request | path: ["", "foo", "bar", ""]}
+    assert ["", "foo", "bar", ""] == split_path(request).path
+  end
+end


### PR DESCRIPTION
Moves path parsing to middleware, `Raxx.ParsePath`. Not calling the
middleware will return the path as a raw string rather than list of
tokens.