### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,14 +138,14 @@ defmodule SubscribeToMessages do
   end
 
   @impl Raxx.Server
-  def handle_info({ChatRoom, data}, state) do
-    outbound = data(data)
+  def handle_info({ChatRoom, :closed}, state) do
+    outbound = tail()
 
     {[outbound], state}
   end
 
-  def handle_info({ChatRoom, :closed}, state) do
-    outbound = tail()
+  def handle_info({ChatRoom, data}, state) do
+    outbound = data(data)
 
     {[outbound], state}
   end


### PR DESCRIPTION
The `:closed` version of handle_info would never match because the `data` will always match.