### PR TITLE
Update Parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.15.10](https://github.com/CrowdHailer/raxx/tree/0.15.10) - 2018-09-02
+
+### Fixed
+
+- `Raxx.HTTP1` to handle case insensitive connect headers.
+
 ## [0.15.9](https://github.com/CrowdHailer/raxx/tree/0.15.9) - 2018-09-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [0.15.10](https://github.com/CrowdHailer/raxx/tree/0.15.10) - 2018-09-02
+## [0.15.10](https://github.com/CrowdHailer/raxx/tree/0.15.10) - 2018-09-03
 
 ### Fixed
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Raxx.Mixfile do
   def project do
     [
       app: :raxx,
-      version: "0.15.9",
+      version: "0.15.10",
       elixir: "~> 1.6",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
To allow the server to handle connection values in a case insensitive
manner this commit forces all header values to be downcase prior to
parsing.