### PR TITLE
Fix typo in Http1 documentation

### DIFF
--- a/lib/raxx/http1.ex
+++ b/lib/raxx/http1.ex
@@ -723,7 +723,7 @@ defmodule Raxx.HTTP1 do
     payload_headers =
       case content_length(headers) do
         nil ->
-          # NOTE `:erlang.iolist_size/1` acceps binaries, i.e. should be `:erlang.iodata_size/1`
+          # NOTE `:erlang.iolist_size/1` accepts binaries, i.e. should be `:erlang.iodata_size/1`
           case :erlang.iolist_size(iodata) do
             0 ->
               []


### PR DESCRIPTION
Simple typo correction.