### PR TITLE
A quick, possibly over simplistic, benchmark for middleware

### DIFF
--- a/bench/middleware.exs
+++ b/bench/middleware.exs
@@ -1,0 +1,43 @@
+defmodule Macroware do
+  defmacro __using__(_) do
+    quote do
+      defoverridable call: 1
+
+      def call(value) do
+        super(value + 1)
+      end
+    end
+  end
+end
+
+defmodule MacroServer do
+  def call(i) do
+    i
+  end
+
+  for _ <- 1..1000 do
+    use Macroware
+  end
+end
+
+1000 = MacroServer.call(0)
+
+defmodule Middleware do
+  def call(value, [next | rest]) do
+    next.call(value + 1, rest)
+  end
+end
+
+defmodule Server do
+  def call(value, []) do
+    value
+  end
+end
+
+stack = for(_ <- 1..999, do: Middleware) ++ [Server]
+1000 = Middleware.call(0, stack)
+
+Benchee.run(%{
+  "macro" => fn -> MacroServer.call(0) end,
+  "stack" => fn -> Middleware.call(0, stack) end
+})

--- a/mix.exs
+++ b/mix.exs
@@ -28,6 +28,7 @@ defmodule Raxx.Mixfile do
       {:cookie, "~> 0.1.0"},
       {:eex_html, "~> 0.1.1"},
       {:dialyxir, "~> 0.5", only: [:dev, :test], runtime: false},
+      {:benchee, "~> 0.13.2", only: :dev},
       {:ex_doc, ">= 0.0.0", only: :dev}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,7 @@
 %{
+  "benchee": {:hex, :benchee, "0.13.2", "30cd4ff5f593fdd218a9b26f3c24d580274f297d88ad43383afe525b1543b165", [:mix], [{:deep_merge, "~> 0.1", [hex: :deep_merge, repo: "hexpm", optional: false]}], "hexpm"},
   "cookie": {:hex, :cookie, "0.1.1", "89438362ee0f0ed400e9f076d617d630f82d682e3fbcf767072a46a6e1ed5781", [:mix], [], "hexpm"},
+  "deep_merge": {:hex, :deep_merge, "0.2.0", "c1050fa2edf4848b9f556fba1b75afc66608a4219659e3311d9c9427b5b680b3", [:mix], [], "hexpm"},
   "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.6", "b6da42b3831458d3ecc57314dff3051b080b9b2be88c2e5aa41cd642a5b044ed", [:mix], [], "hexpm"},
   "eex_html": {:hex, :eex_html, "0.1.1", "df7ad68245068d5fea0dab2a38e5afdc386ec00a5b6445eac6402ed7aa6a2b12", [:mix], [{:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm"},


### PR DESCRIPTION
Several projects I looked at kept benchmarks in a `bench` dir. This PR can add that dir even if we change around some of the benchmarks.