### PR TITLE
Cache dialyzer artifacts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,7 @@ otp_release:
   - 21.0
 env:
   - MIX_ENV=test
-before_install:
-  - sudo apt-get install -y tree
 before_script:
-  - ls -alh
-  # checking if the cache gets brought back.
-  - tree _build
   - mix local.hex --force && mix deps.get
 script:
   - mix test
@@ -24,4 +19,3 @@ before_cache:
   # should only keep the dialyzer artifacts
   - mix clean
   - mix deps.clean --all
-  - tree _build

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ before_install:
   - sudo apt-get install -y tree
 before_script:
   - ls -alh
+  # checking if the cache gets brought back.
   - tree _build
   - mix local.hex --force && mix deps.get
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ before_cache:
   # should only keep the dialyzer artifacts
   - mix clean
   - mix deps.clean --all
-  # - tree _build
+  - tree _build

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,8 @@ script:
   - mix format --check-formatted
   - mix dialyzer --halt-exit-status
 cache:
-  - _build
+  directories:
+    - _build
 before_cache:
   # should only keep the dialyzer artifacts
   - mix clean

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,10 @@ script:
   - mix test
   - mix format --check-formatted
   - mix dialyzer --halt-exit-status
+cache:
+  - _build
+before_cache:
+  # should only keep the dialyzer artifacts
+  - mix clean
+  - mix deps.clean --all
+  # - tree _build

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,11 @@ otp_release:
   - 21.0
 env:
   - MIX_ENV=test
+before_install:
+  - sudo apt-get install -y tree
 before_script:
+  - ls -alh
+  - tree _build
   - mix local.hex --force && mix deps.get
 script:
   - mix test


### PR DESCRIPTION
In https://travis-ci.org/nietaki/raxx/jobs/453355942 you can see that it works and what the state of `_build` directory is when it gets cached - it's the plt files and nothing else.

It brings the CI run time from 12 minutes down to 1 minute :tada: 

We could overdo the caching and cache the whole `_builld` and `deps` directories for an even shorter build time, but I think it would be overkill - it would expose us to some "unknown unknows"-type problems and make individual CI builds less isolated.

Please merge-squash to hide my commit message babbling ;)