### PR TITLE
Work around deprecation warnings messing with the compilation.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ env:
 before_script:
   - mix local.hex --force && mix deps.get
 script:
-  - mix compile
   - mix test --trace --include deprecations
   - mix format --check-formatted
   - mix dialyzer --halt-exit-status

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,8 @@ env:
 before_script:
   - mix local.hex --force && mix deps.get
 script:
-  - mix test
+  - mix compile
+  - mix test --trace --include deprecations
   - mix format --check-formatted
   - mix dialyzer --halt-exit-status
 cache:

--- a/mix.exs
+++ b/mix.exs
@@ -14,7 +14,8 @@ defmodule Raxx.Mixfile do
       ],
       description: description(),
       docs: [extras: ["README.md"], main: "readme", assets: ["assets"]],
-      package: package()
+      package: package(),
+      aliases: aliases()
     ]
   end
 
@@ -44,6 +45,12 @@ defmodule Raxx.Mixfile do
       maintainers: ["Peter Saxton"],
       licenses: ["Apache 2.0"],
       links: %{"GitHub" => "https://github.com/crowdhailer/raxx"}
+    ]
+  end
+
+  defp aliases do
+    [
+      test: ["test --exclude deprecations"]
     ]
   end
 end

--- a/test/raxx/router_test.exs
+++ b/test/raxx/router_test.exs
@@ -61,18 +61,38 @@ defmodule Raxx.RouterTest do
   end
 
   describe "original routing API" do
-    defmodule OriginalRouter do
-      use Raxx.Server
+    @describetag :deprecations
+    setup do
+      # the setup makes sure the code that causes warnings only
+      # gets compiled if the deprecations tests are run
+      original_router_module_code = """
+      defmodule OriginalRouter do
+        alias Raxx.RouterTest.HomePage
+        alias Raxx.RouterTest.UsersPage
+        alias Raxx.RouterTest.UserPage
+        alias Raxx.RouterTest.CreateUser
+        alias Raxx.RouterTest.InvalidReturn
+        alias Raxx.RouterTest.NotFoundPage
 
-      use Raxx.Router, [
-        {%{method: :GET, path: []}, HomePage},
-        {%{method: :GET, path: ["users"]}, UsersPage},
-        {%{method: :GET, path: ["users", _id]}, UserPage},
-        {%{method: :POST, path: ["users"]}, CreateUser},
-        {%{method: :GET, path: ["invalid"]}, InvalidReturn},
-        {%{method: :POST, path: ["invalid"]}, InvalidReturn},
-        {_, NotFoundPage}
-      ]
+        use Raxx.Server
+
+        use Raxx.Router, [
+          {%{method: :GET, path: []}, HomePage},
+          {%{method: :GET, path: ["users"]}, UsersPage},
+          {%{method: :GET, path: ["users", _id]}, UserPage},
+          {%{method: :POST, path: ["users"]}, CreateUser},
+          {%{method: :GET, path: ["invalid"]}, InvalidReturn},
+          {%{method: :POST, path: ["invalid"]}, InvalidReturn},
+          {_, NotFoundPage}
+        ]
+      end
+      """
+
+      if !Code.ensure_loaded?(OriginalRouter) do
+        Code.compile_string(original_router_module_code, "nofile")
+      end
+
+      {:ok, %{}}
     end
 
     test "will route to homepage" do


### PR DESCRIPTION
This will exclude deprecation tests from local test runs, but still run them in CI.

It also fixes the issue where running the tests without compiling the project first made the whole thing fail.