### PR TITLE
Implementing middlewares

### DIFF
--- a/lib/cors.ex
+++ b/lib/cors.ex
@@ -1,0 +1,121 @@
+defmodule CORS do
+  @doc """
+  ## Examples
+      iex> CORS.check(:GET, [], test_config())
+      {:ok, :no_cors}
+
+      iex> CORS.check(:OPTIONS, [], test_config())
+      {:ok, :no_cors}
+
+      # Need an any config
+      # Test config accepts PUT but not delete
+
+  ### Simple CORS requests
+
+      iex> headers = [{"origin", "other.example.com"}]
+      ...> CORS.check(:GET, headers, test_config())
+      {:ok, {:simple, [{"access-control-allow-origin", "other.example.com"}]}}
+
+      iex> headers = [{"origin", "other.example.com"}]
+      ...> CORS.check(:DELETE, headers, test_config())
+      {:error, {:simple, :invalid_method}}
+
+  ### Preflight CORS requests
+
+      {:ok, {:preflight, [{"access-control-allow-origin", "other.example.com"}, {"access-control-allow-methods", "PUT"}]}}
+      iex> headers = [
+      ...>   {"origin", "other.example.com"},
+      ...>   {"access-control-request-method", "PUT"},
+      ...> ]
+      ...> CORS.check(:OPTIONS, headers, test_config())
+      {:ok, {:preflight, [{"access-control-allow-origin", "other.example.com"}, {"access-control-allow-methods", "PUT"}]}}
+
+      iex> headers = [
+      ...>   {"origin", "bad.example.com"},
+      ...>   {"access-control-request-method", "PUT"},
+      ...> ]
+      ...> CORS.check(:OPTIONS, headers, test_config())
+      {:error, {:preflight, :invalid_origin}}
+  """
+  def check(method, headers, config) do
+    case :proplists.get_all_values("origin", headers) do
+      [] ->
+        {:ok, :no_cors}
+
+      [request_origin] ->
+        case {method, :proplists.get_all_values("access-control-request-method", headers)} do
+          {:OPTIONS, [request_method]} ->
+            check_preflight(request_origin, request_method, method, headers, config)
+
+          {_method, []} ->
+            check_simple(request_origin, method, headers, config)
+        end
+
+        #
+        # _ ->
+        #   raise ArgumentError, "More than one header found for `#{name}`"
+    end
+  end
+
+  defp check_preflight(request_origin, request_method, _, _, config) do
+    case check_origin(request_origin, config.origins) do
+      {:ok, allow_origin} ->
+        case check_method(request_method, config.allow_methods) do
+          # What do you put if Any method is allowed
+          {:ok, allow_methods} ->
+            {:ok,
+             {:preflight,
+              [
+                {"access-control-allow-origin", allow_origin},
+                {"access-control-allow-methods", Enum.join(allow_methods, ", ")}
+              ]}}
+
+          {:error, reason} ->
+            {:error, {:preflight, reason}}
+        end
+
+      {:error, reason} ->
+        {:error, {:preflight, reason}}
+    end
+  end
+
+  defp check_simple(request_origin, method, _, config) do
+    case check_origin(request_origin, config.origins) do
+      {:ok, allow_origin} ->
+        case check_method("#{method}", config.allow_methods) do
+          # Simple request does not need to expose allow method
+          {:ok, _allow_methods} ->
+            {:ok,
+             {:simple,
+              [
+                {"access-control-allow-origin", allow_origin}
+              ]}}
+
+          {:error, reason} ->
+            {:error, {:simple, reason}}
+        end
+    end
+  end
+
+  defp check_origin(request_origin, [request_origin]) do
+    {:ok, request_origin}
+  end
+
+  defp check_origin(request_origin, :any) do
+    {:ok, request_origin}
+  end
+
+  defp check_origin(_, _) do
+    {:error, :invalid_origin}
+  end
+
+  defp check_method(request_method, methods) when is_binary(request_method) do
+    if request_method in (methods ++ ["GET", "HEAD", "POST"]) do
+      {:ok, methods}
+    else
+      {:error, :invalid_method}
+    end
+  end
+
+  # TODO function list regex
+end

--- a/lib/raxx/middlewares/cors.ex
+++ b/lib/raxx/middlewares/cors.ex
@@ -1,0 +1,62 @@
+defmodule Raxx.Middlewares.CORS do
+  use Raxx.Middleware
+
+  # vary header appear twice? I think ok
+  @impl Raxx.Middleware
+  def process_head(request, config, next) do
+    case CORS.check(request.method, request.headers, config) do
+      {:ok, :no_cors} ->
+        continue_processing(request, [], next)
+
+      {:ok, {:simple, additional_headers}} ->
+        continue_processing(request, additional_headers, next)
+
+      {:error, {:simple, _reason}} ->
+        # I'm surprised this doesn't halt
+        continue_processing(request, [], next)
+
+      {:ok, {:preflight, headers}} ->
+        %{Raxx.response(:ok) | headers: headers}
+
+      {:error, {:preflight, _reason}} ->
+        {:halt, []}
+    end
+  end
+
+  defp continue_processing(request, additional_headers, next) do
+    {parts, next} = Raxx.Server.handle_head(next, request)
+    parts = modify_response_parts(parts, additional_headers)
+    {parts, additional_headers, next}
+  end
+
+  @impl Raxx.Middleware
+  def process_data(data, additional_headers, next) do
+    {parts, next} = Raxx.Server.handle_data(next, data)
+    parts = modify_response_parts(parts, additional_headers)
+    {parts, additional_headers, next}
+  end
+
+  @impl Raxx.Middleware
+  def process_tail(tail, additional_headers, next) do
+    {parts, next} = Raxx.Server.handle_tail(next, tail)
+    parts = modify_response_parts(parts, additional_headers)
+    {parts, additional_headers, next}
+  end
+
+  @impl Raxx.Middleware
+  def process_info(info, additional_headers, next) do
+    {parts, next} = Raxx.Server.handle_info(next, info)
+    parts = modify_response_parts(parts, additional_headers)
+    {parts, additional_headers, next}
+  end
+
+  defp modify_response_parts(parts, additional_headers) do
+    Enum.map(parts, fn
+      response = %Raxx.Response{headers: headers} ->
+        %{response | headers: headers ++ additional_headers}
+
+      other ->
+        other
+    end)
+  end
+end

--- a/lib/raxx/middlewares/head_request.ex
+++ b/lib/raxx/middlewares/head_request.ex
@@ -1,0 +1,67 @@
+defmodule Raxx.Middlewares.HeadRequest do
+  @moduledoc """
+  An example router that allows you to handle HEAD requests with GET handlers
+  """
+
+  alias Raxx.Server
+  alias Raxx.Middleware
+
+  @behaviour Middleware
+
+  @impl Middleware
+  def process_head(request = %{method: :HEAD}, _config, inner_server) do
+    request = %{request | method: :GET}
+    state = :engage
+    {parts, inner_server} = Server.handle_head(inner_server, request)
+
+    parts = modify_response_parts(parts, state)
+    {parts, state, inner_server}
+  end
+
+  def process_head(request = %{method: _}, _config, inner_server) do
+    {parts, inner_server} = Server.handle_head(inner_server, request)
+    {parts, :disengage, inner_server}
+  end
+
+  @impl Middleware
+  def process_data(data, state, inner_server) do
+    {parts, inner_server} = Server.handle_data(inner_server, data)
+    parts = modify_response_parts(parts, state)
+    {parts, state, inner_server}
+  end
+
+  @impl Middleware
+  def process_tail(tail, state, inner_server) do
+    {parts, inner_server} = Server.handle_tail(inner_server, tail)
+    parts = modify_response_parts(parts, state)
+    {parts, state, inner_server}
+  end
+
+  @impl Middleware
+  def process_info(info, state, inner_server) do
+    {parts, inner_server} = Server.handle_info(inner_server, info)
+    parts = modify_response_parts(parts, state)
+    {parts, state, inner_server}
+  end
+
+  defp modify_response_parts(parts, :disengage) do
+    parts
+  end
+
+  defp modify_response_parts(parts, :engage) do
+    Enum.flat_map(parts, &do_handle_response_part(&1))
+  end
+
+  defp do_handle_response_part(response = %Raxx.Response{}) do
+    # the content-length should remain the same
+    [%Raxx.Response{response | body: false}]
+  end
+
+  defp do_handle_response_part(%Raxx.Data{}) do
+    []
+  end
+
+  defp do_handle_response_part(%Raxx.Tail{}) do
+    []
+  end
+end

--- a/lib/raxx/middlewares/method_override.ex
+++ b/lib/raxx/middlewares/method_override.ex
@@ -1,0 +1,101 @@
+defmodule Raxx.Middlewares.MethodOverride do
+  @moduledoc """
+  Allows browser to emulate using HTTP verbs other than `POST`.
+
+  Only the `POST` method will be overridden,
+  It can be overridden to any of the listed HTTP verbs.
+  - `PUT`
+  - `PATCH`
+  - `DELETE`
+
+  The emulated method is is denoted by the `_method` parameter of the url query.
+
+  ## Examples
+
+      # override POST to PUT from query value
+      iex> request(:POST, "/?_method=PUT")
+      ...> |> override_method()
+      ...> |> Map.get(:method)
+      :PUT
+
+      # override POST to PATCH from query value
+      iex> request(:POST, "/?_method=PATCH")
+      ...> |> override_method()
+      ...> |> Map.get(:method)
+      :PATCH
+
+      # override POST to DELETE from query value
+      iex> request(:POST, "/?_method=DELETE")
+      ...> |> override_method()
+      ...> |> Map.get(:method)
+      :DELETE
+
+      # overridding method removes the _method field from the query
+      iex> request(:POST, "/?_method=PUT")
+      ...> |> override_method()
+      ...> |> Map.get(:query)
+      %{}
+
+      # override works with lowercase query value
+      iex> request(:POST, "/?_method=delete")
+      ...> |> override_method()
+      ...> |> Map.get(:method)
+      :DELETE
+
+      # # at the moment breaks deleberatly due to unknown method
+      # # does not allow unknown methods
+      # iex> request(:POST, "/?_method=PARTY")
+      # ...> |> override_method()
+      # ...> |> Map.get(:method)
+      # :POST
+
+      # leaves non-POST requests unmodified, e.g. GET
+      iex> request(:GET, "/?_method=DELETE")
+      ...> |> override_method()
+      ...> |> Map.get(:method)
+      :GET
+
+      # leaves non-POST requests unmodified, e.g. PUT
+      # Not entirely sure of the logic here.
+      iex> request(:PUT, "/?_method=DELETE")
+      ...> |> override_method()
+      ...> |> Map.get(:method)
+      :PUT
+
+      # queries with out a _method field are a no-op
+      iex> request(:POST, "/?other=PUT")
+      ...> |> override_method()
+      ...> |> Map.get(:method)
+      :POST
+  """
+
+  use Raxx.Middleware
+
+  @doc """
+  Modify a requests method based on query parameters
+  """
+  def override_method(request = %{method: :POST}) do
+    query = Raxx.get_query(request)
+    {method, query} = Map.pop(query, "_method")
+
+    case method && String.upcase(method) do
+      nil ->
+        request
+
+      method when method in ["PUT", "PATCH", "DELETE"] ->
+        method = String.to_existing_atom(method)
+        %{request | method: method, query: query}
+    end
+  end
+
+  def override_method(request) do
+    request
+  end
+
+  @impl Raxx.Middleware
+  def process_head(request, state, next) do
+    request = override_method(request)
+    {parts, next} = Raxx.Server.handle_head(next, request)
+    {parts, state, next}
+  end
+end

--- a/test/cors_test.exs
+++ b/test/cors_test.exs
@@ -1,0 +1,16 @@
+defmodule CORSTest do
+  use ExUnit.Case
+  doctest CORS
+
+  def test_config do
+    %{
+      origins: ["other.example.com"],
+      # TODO default PUT PATCH DELETE
+      allow_methods: ["PUT"],
+      # headers than can be sent by the request
+      allow_headers: [],
+      # headers that the client can use in a response
+      expose_headers: []
+    }
+  end
+end

--- a/test/raxx/middlewares/head_request_test.exs
+++ b/test/raxx/middlewares/head_request_test.exs
@@ -1,0 +1,52 @@
+defmodule Raxx.Middlewares.HeadRequestTest do
+  use ExUnit.Case
+  import Raxx
+
+  alias Raxx.Server
+
+  defmodule SimpleApp do
+    use Raxx.SimpleServer
+
+    @impl Raxx.SimpleServer
+    def handle_request(request, _) do
+      send(self(), request)
+
+      response(:ok)
+      |> set_body("Hello, World!")
+    end
+  end
+
+  setup do
+    stack = Raxx.Stack.new([{Raxx.Middlewares.HeadRequest, nil}], {SimpleApp, nil})
+    {:ok, stack: stack}
+  end
+
+  test "The response to a GET request is unchanged", %{stack: stack} do
+    request = request(:GET, "/")
+
+    assert {[response], _} = Server.handle_head(stack, request)
+    assert_receive %{method: :GET}
+    assert response.body == "Hello, World!"
+  end
+
+  test "The response to a HEAD request is returned without body", %{stack: stack} do
+    request = request(:HEAD, "/")
+
+    assert {[response], _} = Server.handle_head(stack, request)
+    assert_receive %{method: :GET}
+    assert get_content_length(response) == 13
+    assert response.body == false
+  end
+
+  test "A POST request is unchanged", %{stack: stack} do
+    request =
+      request(:POST, "/")
+      |> set_body(true)
+
+    assert {[], stack} = Server.handle_head(stack, request)
+    assert {[], stack} = Server.handle_data(stack, "some data")
+    assert {[response], _} = Server.handle_tail(stack, [])
+    assert_receive %{method: :POST}
+    assert response.body == "Hello, World!"
+  end
+end

--- a/test/raxx/middlewares/method_override_test.exs
+++ b/test/raxx/middlewares/method_override_test.exs
@@ -1,0 +1,33 @@
+defmodule Raxx.Middlewares.MethodOverrideTest do
+  use ExUnit.Case
+  import Raxx
+  import Raxx.Middlewares.MethodOverride
+  doctest Raxx.Middlewares.MethodOverride
+
+  alias Raxx.Server
+
+  defmodule SimpleApp do
+    use Raxx.SimpleServer
+
+    @impl Raxx.SimpleServer
+    def handle_request(request, _) do
+      send(self(), request)
+
+      response(:ok)
+      |> set_body("Hello, World!")
+    end
+  end
+
+  setup do
+    stack = Raxx.Stack.new([{Raxx.Middlewares.MethodOverride, nil}], {SimpleApp, nil})
+    {:ok, stack: stack}
+  end
+
+  test "Query can be used to overwrite POST method", %{stack: stack} do
+    request = request(:POST, "/?_method=PUT")
+
+    assert {[response], _} = Server.handle_head(stack, request)
+    assert_receive %{method: :PUT}
+    assert response.body == "Hello, World!"
+  end
+end


### PR DESCRIPTION
Implement a selection of middlewares.

This has been done all in one PR so that it can be coordinated with the final improvements to the middleware interface

### CORS

There appear to be several "choices" when implementing a CORS middleware. Places where the existing tools (CORSPlug and Corsica) behave differently.

- Should an Invalid CORS request be passed up the stack and no cors information added to the response
- CORSPlug does not separate expose_headers from accept_headers, although I am now convinced that it should
- Should the accept-headers response list all possible headers or only those requested
- What to do if the configuration supports an any method paramenter, I don't see any value in this is there any wild implementation that needs to support a huge number of HTTP methods

- [Understanding CORS](https://spring.io/understanding/CORS)
- [Cross origin resource sharing](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS)

Flow chart [1](https://www.html5rocks.com/static/images/cors_server_flowchart.png) [2](https://i.stack.imgur.com/TIETI.jpg)
