### PR TITLE
Make usage of iodata made more explicit in the docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Current
+
+### Changed
+
+- Usage of `iodata` made more explicit in the docs.
+
 ## [1.0.1](https://github.com/CrowdHailer/raxx/tree/1.0.1) - 2019-05-01
 
 ### Added

--- a/lib/raxx.ex
+++ b/lib/raxx.ex
@@ -38,7 +38,7 @@ defmodule Raxx do
   The body of a Raxx message.
 
   The body can be:
-  - part of the message (`binary`).
+  - included in the message (as `iodata`).
   - empty (`false`).
   - present but unknown (`true`).
   """

--- a/lib/raxx/data.ex
+++ b/lib/raxx/data.ex
@@ -9,7 +9,7 @@ defmodule Raxx.Data do
   Container for a section of an HTTP message.
   """
   @type t :: %__MODULE__{
-          data: binary
+          data: iodata
         }
 
   @enforce_keys [:data]

--- a/lib/raxx/http1.ex
+++ b/lib/raxx/http1.ex
@@ -3,7 +3,7 @@ defmodule Raxx.HTTP1 do
   Toolkit for parsing and serializing requests to HTTP/1.1 format.
 
   The majority of functions return iolists and not compacted binaries.
-  To efficiently turn a list into a binart use `:erlang.iolist_to_binary/1`
+  To efficiently turn a list into a binary use `IO.iodata_to_binary/1`
 
   ## Notes
 
@@ -52,7 +52,7 @@ defmodule Raxx.HTTP1 do
       iex> request = Raxx.request(:GET, "http://example.com/path?qs")
       ...> |> Raxx.set_header("accept", "text/plain")
       ...> {head, body} =  Raxx.HTTP1.serialize_request(request)
-      ...> :erlang.iolist_to_binary(head)
+      ...> IO.iodata_to_binary(head)
       "GET /path?qs HTTP/1.1\r\nhost: example.com\r\naccept: text/plain\r\n\r\n"
       iex> body
       {:complete, ""}
@@ -61,7 +61,7 @@ defmodule Raxx.HTTP1 do
       ...> |> Raxx.set_header("content-type", "text/plain")
       ...> |> Raxx.set_body(true)
       ...> {head, body} =  Raxx.HTTP1.serialize_request(request)
-      ...> :erlang.iolist_to_binary(head)
+      ...> IO.iodata_to_binary(head)
       "POST / HTTP/1.1\r\nhost: example.com\r\ntransfer-encoding: chunked\r\ncontent-type: text/plain\r\n\r\n"
       iex> body
       :chunked
@@ -70,7 +70,7 @@ defmodule Raxx.HTTP1 do
       ...> |> Raxx.set_header("content-length", "13")
       ...> |> Raxx.set_body(true)
       ...> {head, body} =  Raxx.HTTP1.serialize_request(request)
-      ...> :erlang.iolist_to_binary(head)
+      ...> IO.iodata_to_binary(head)
       "POST / HTTP/1.1\r\nhost: example.com\r\ncontent-length: 13\r\n\r\n"
       iex> body
       {:bytes, 13}
@@ -83,13 +83,13 @@ defmodule Raxx.HTTP1 do
       iex> request = Raxx.request(:GET, "http://example.com/")
       ...> |> Raxx.set_header("accept", "text/plain")
       ...> {head, _body} =  Raxx.HTTP1.serialize_request(request, connection: :close)
-      ...> :erlang.iolist_to_binary(head)
+      ...> IO.iodata_to_binary(head)
       "GET / HTTP/1.1\r\nhost: example.com\r\nconnection: close\r\naccept: text/plain\r\n\r\n"
 
       iex> request = Raxx.request(:GET, "http://example.com/")
       ...> |> Raxx.set_header("accept", "text/plain")
       ...> {head, _body} =  Raxx.HTTP1.serialize_request(request, connection: :keepalive)
-      ...> :erlang.iolist_to_binary(head)
+      ...> IO.iodata_to_binary(head)
       "GET / HTTP/1.1\r\nhost: example.com\r\nconnection: keep-alive\r\naccept: text/plain\r\n\r\n"
   """
   @spec serialize_request(Raxx.Request.t(), [{:connection, connection_status}]) ::
@@ -386,7 +386,7 @@ defmodule Raxx.HTTP1 do
   end
 
   @doc ~S"""
-  Serialize a response to an iolist
+  Serialize a response to iodata
 
   Because of HEAD requests we should keep body separate
   ## Examples
@@ -395,7 +395,7 @@ defmodule Raxx.HTTP1 do
       ...> |> Raxx.set_header("content-type", "text/plain")
       ...> |> Raxx.set_body("Hello, World!")
       ...> {head, body} =  Raxx.HTTP1.serialize_response(response)
-      ...> :erlang.iolist_to_binary(head)
+      ...> IO.iodata_to_binary(head)
       "HTTP/1.1 200 OK\r\ncontent-type: text/plain\r\ncontent-length: 13\r\n\r\n"
       iex> body
       {:complete, "Hello, World!"}
@@ -405,7 +405,7 @@ defmodule Raxx.HTTP1 do
       ...> |> Raxx.set_header("content-type", "text/plain")
       ...> |> Raxx.set_body(true)
       ...> {head, body} =  Raxx.HTTP1.serialize_response(response)
-      ...> :erlang.iolist_to_binary(head)
+      ...> IO.iodata_to_binary(head)
       "HTTP/1.1 200 OK\r\ncontent-length: 13\r\ncontent-type: text/plain\r\n\r\n"
       iex> body
       {:bytes, 13}
@@ -414,7 +414,7 @@ defmodule Raxx.HTTP1 do
       ...> |> Raxx.set_header("content-type", "text/plain")
       ...> |> Raxx.set_body(true)
       ...> {head, body} =  Raxx.HTTP1.serialize_response(response)
-      ...> :erlang.iolist_to_binary(head)
+      ...> IO.iodata_to_binary(head)
       "HTTP/1.1 200 OK\r\ntransfer-encoding: chunked\r\ncontent-type: text/plain\r\n\r\n"
       iex> body
       :chunked
@@ -429,7 +429,7 @@ defmodule Raxx.HTTP1 do
       ...> |> Raxx.set_header("foo", "bar")
       ...> |> Raxx.HTTP1.serialize_response()
       ...> |> elem(0)
-      ...> |> :erlang.iolist_to_binary()
+      ...> |> IO.iodata_to_binary()
       "HTTP/1.1 204 No Content\r\nfoo: bar\r\n\r\n"
 
   ### *https://tools.ietf.org/html/rfc7230#section-6.1*
@@ -442,14 +442,14 @@ defmodule Raxx.HTTP1 do
       ...> |> Raxx.set_header("foo", "bar")
       ...> |> Raxx.HTTP1.serialize_response(connection: :close)
       ...> |> elem(0)
-      ...> |> :erlang.iolist_to_binary()
+      ...> |> IO.iodata_to_binary()
       "HTTP/1.1 204 No Content\r\nconnection: close\r\nfoo: bar\r\n\r\n"
 
       iex> Raxx.response(204)
       ...> |> Raxx.set_header("foo", "bar")
       ...> |> Raxx.HTTP1.serialize_response(connection: :keepalive)
       ...> |> elem(0)
-      ...> |> :erlang.iolist_to_binary()
+      ...> |> IO.iodata_to_binary()
       "HTTP/1.1 204 No Content\r\nconnection: keep-alive\r\nfoo: bar\r\n\r\n"
   """
   @spec serialize_response(Raxx.Response.t(), [{:connection, connection_status}]) ::

--- a/lib/raxx/middleware.ex
+++ b/lib/raxx/middleware.ex
@@ -95,8 +95,21 @@ defmodule Raxx.Middleware do
   call through using `Raxx.Server`'s `handle_*` helper functions and return
   the `inner_server` unmodified.
 
-  NOTE: As you can see in the above example, the middleware can even modify
-  the `info` messages sent to the server and is responsible for forwarding them.
+  ## Gotchas
+
+  ### Info messages forwarding
+
+  As you can see in the above example, the middleware can even modify
+  the `info` messages sent to the server and is responsible for forwarding them
+  to the inner servers.
+
+  ### Iodata contents
+
+  While much of the time the request body, response body and data chunks will
+  be represented with binaries, they can be represented
+  as [`iodata`](https://hexdocs.pm/elixir/typespecs.html#built-in-types).
+
+  A robust middleware should handle that.
   """
 
   @typedoc """

--- a/lib/raxx/server.ex
+++ b/lib/raxx/server.ex
@@ -12,7 +12,7 @@ defmodule Raxx.Server do
 
   **Send complete response as soon as request headers are received.**
 
-      defmodule SimpleServer do
+      defmodule HelloServer do
         use Raxx.Server
 
         def handle_head(%Raxx.Request{method: :GET, path: []}, _state) do
@@ -32,8 +32,8 @@ defmodule Raxx.Server do
           {[], {:file, device}}
         end
 
-        def handle_data(body, state = {:file, device}) do
-          IO.write(device, body)
+        def handle_data(body_chunk, state = {:file, device}) do
+          IO.write(device, body_chunk)
           {[], state}
         end
 
@@ -81,7 +81,7 @@ defmodule Raxx.Server do
 
   The body of a Raxx message (Raxx.Request or `Raxx.Response`) may be one of three types:
 
-  - `io_list` - This is the complete body for the message.
+  - `iodata` - This is the complete body for the message.
   - `:false` - There **is no** body, for example `:GET` requests never have a body.
   - `:true` - There **is** a body, it can be processed as it is received
 


### PR DESCRIPTION
Notes on the changes:

Based on both Erlang and Elixir typespecs `iodata` is basically `iolist | binary`, which is more accurate in our usecase and more intutive in my book.

I changed example usages of `:erlang.iolist_to_binary/1` to `IO.iodata_to_binary/1` to make it more intuitive and not startle people who are afraid of Erlang. The latter calls the former under the hood anyways. I kept the occurrences in the source code as they were, they don't make much of a difference.

`SimpleServer` renamed to something that doesn't already have a meaning in Raxx world in one of the examples.