### PR TITLE
Raxx.Request.uri/1 function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Current
 
+### Added
+
+- `Raxx.Request.uri/1` and docs for `Raxx.Request` module.
+
 ### Changed
 
 - Usage of `iodata` made more explicit in the docs.

--- a/lib/raxx/request.ex
+++ b/lib/raxx/request.ex
@@ -63,10 +63,12 @@ defmodule Raxx.Request do
     https: 443
   }
 
+  # TODO docs
   def host(%__MODULE__{authority: authority}) do
     hd(String.split(authority, ":"))
   end
 
+  # TODO docs
   @spec port(t, %{optional(atom) => :inet.port_number()}) :: :inet.port_number()
   def port(%__MODULE__{scheme: scheme, authority: authority}, default_ports \\ @default_ports) do
     case String.split(authority, ":") do
@@ -79,5 +81,28 @@ defmodule Raxx.Request do
             port
         end
     end
+  end
+
+  # TODO docs
+  @spec uri(t) :: URI.t()
+  def uri(%__MODULE__{} = request) do
+    scheme =
+      case request.scheme do
+        nil -> nil
+        atom when is_atom(atom) -> Atom.to_string(atom)
+      end
+
+    %URI{
+      authority: request.authority,
+      host: Raxx.request_host(request),
+      path: request.raw_path,
+      port: port(request),
+      query: request.query,
+      scheme: scheme,
+      # you can't provide userinfo in a http request url (anymore)
+      # pulling it out of Authorization headers would go agains the
+      # main use-case for this function
+      userinfo: nil
+    }
   end
 end

--- a/lib/raxx/request.ex
+++ b/lib/raxx/request.ex
@@ -63,12 +63,23 @@ defmodule Raxx.Request do
     https: 443
   }
 
-  # TODO docs
+  @doc """
+  Return the host value for the request.
+
+  The `t:Raxx.Request.t/0` struct contains `authority` field, which
+  may contain the port number. This function returns the host value which
+  won't include the port number.
+  """
   def host(%__MODULE__{authority: authority}) do
     hd(String.split(authority, ":"))
   end
 
-  # TODO docs
+  @doc """
+  Return the port number used for the request.
+
+  If no port number is explicitly specified in the request url, the 
+  default one for the scheme is used.
+  """
   @spec port(t, %{optional(atom) => :inet.port_number()}) :: :inet.port_number()
   def port(%__MODULE__{scheme: scheme, authority: authority}, default_ports \\ @default_ports) do
     case String.split(authority, ":") do
@@ -83,7 +94,14 @@ defmodule Raxx.Request do
     end
   end
 
-  # TODO docs
+  @doc """
+  Returns an `URI` struct corresponding to the url used in the provided request.
+
+  **NOTE**: the `userinfo` field of the `URI` will always be `nil`, even if there
+  is `Authorization` header basic auth information contained in the request.
+
+  The `fragment` will also be `nil`, as the servers don't have access to it.
+  """
   @spec uri(t) :: URI.t()
   def uri(%__MODULE__{} = request) do
     scheme =
@@ -100,7 +118,7 @@ defmodule Raxx.Request do
       query: request.query,
       scheme: scheme,
       # you can't provide userinfo in a http request url (anymore)
-      # pulling it out of Authorization headers would go agains the
+      # pulling it out of Authorization headers would go against the
       # main use-case for this function
       userinfo: nil
     }

--- a/test/raxx/request_test.exs
+++ b/test/raxx/request_test.exs
@@ -62,6 +62,15 @@ defmodule Raxx.RequestTest do
       assert uri.port == 4321
     end
 
-    # TODO test for the userinfo
+    test "the uri won't contain userinfo" do
+      url = "https://example.com/"
+
+      request =
+        Raxx.request(:GET, url)
+        |> Raxx.set_header("authorization", "Basic YWxhZGRpbjpvcGVuc2VzYW1l")
+
+      uri = Request.uri(request)
+      assert uri.userinfo == nil
+    end
   end
 end

--- a/test/raxx/request_test.exs
+++ b/test/raxx/request_test.exs
@@ -1,0 +1,67 @@
+defmodule Raxx.RequestTest do
+  use ExUnit.Case
+  alias Raxx.Request
+
+  describe "uri/1" do
+    test "handles a basic https case correctly" do
+      request = Raxx.request(:GET, "https://example.com/")
+      uri = Request.uri(request)
+
+      assert %URI{
+               authority: "example.com",
+               fragment: nil,
+               host: "example.com",
+               path: "/",
+               port: 443,
+               query: nil,
+               scheme: "https",
+               userinfo: nil
+             } == uri
+    end
+
+    test "handles a basic http case correctly" do
+      request = Raxx.request(:GET, "http://example.com/")
+      uri = Request.uri(request)
+
+      assert %URI{
+               authority: "example.com",
+               fragment: nil,
+               host: "example.com",
+               path: "/",
+               port: 80,
+               query: nil,
+               scheme: "http",
+               userinfo: nil
+             } == uri
+    end
+
+    test "handles the case with normal path" do
+      request = Raxx.request(:GET, "https://example.com/foo/bar")
+      uri = Request.uri(request)
+      assert uri.path == "/foo/bar"
+    end
+
+    test "handles the case with duplicate slashes" do
+      request = Raxx.request(:GET, "https://example.com/foo//bar")
+      uri = Request.uri(request)
+      assert uri.path == "/foo//bar"
+    end
+
+    test "passes through the query" do
+      request = Raxx.request(:GET, "https://example.com?foo=bar&baz=ban")
+      uri = Request.uri(request)
+      assert uri.query == "foo=bar&baz=ban"
+    end
+
+    test "if there's a port number in the request, it is contained in the authority, but not the host" do
+      url = "https://example.com:4321/foo/bar"
+      request = Raxx.request(:GET, url)
+      uri = Request.uri(request)
+      assert uri.host == "example.com"
+      assert uri.authority == "example.com:4321"
+      assert uri.port == 4321
+    end
+
+    # TODO test for the userinfo
+  end
+end


### PR DESCRIPTION
I added some more function docs in the Request module. They might contain a bit more information than necessary, but I figured it might make it easier to use the functions without looking up additional info on HTTP / URIs. 

The reason why it would have been useful for me was for redirects in middleware.