### PR TITLE
Removes: warning: Code.ensure_compiled?/1 is deprecate

### DIFF
--- a/lib/raxx/middleware.ex
+++ b/lib/raxx/middleware.ex
@@ -196,12 +196,12 @@ defmodule Raxx.Middleware do
   @spec is_implemented?(module) :: boolean
   def is_implemented?(module) when is_atom(module) do
     # taken from Raxx.Server
-    if Code.ensure_compiled?(module) do
-      module.module_info[:attributes]
-      |> Keyword.get(:behaviour, [])
-      |> Enum.member?(__MODULE__)
-    else
-      false
+    case Code.ensure_compiled(module) do
+      {:module, module} ->
+        module.module_info[:attributes]
+        |> Keyword.get(:behaviour, [])
+        |> Enum.member?(__MODULE__)
+      _ -> false
     end
   end
 end


### PR DESCRIPTION
```bash
  warning: Code.ensure_compiled?/1 is deprecated. Use Code.ensure_compiled/1 instead (see the proper disclaimers in its docs)
  lib/raxx/middleware.ex:199: Raxx.Middleware.is_implemented?/1
```